### PR TITLE
Make setup.py parseable on Python3 with LANG unset

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,11 +16,11 @@ script_dirname = os.path.join(os.path.dirname(__file__))
 __VERSION__ = None
 # get __VERSION__ variable from file
 version_file = os.path.join(script_dirname, 'version.py')
-exec(open(version_file).read().decode("utf-8"))
+exec(open(version_file, "rb").read().decode("utf-8"))
 
 
 def read(readme):
-    return open(os.path.join(script_dirname, readme)).read().decode("utf-8")
+    return open(os.path.join(script_dirname, readme), "rb").read().decode("utf-8")
 
 setup(
     name='urlextract',

--- a/setup.py
+++ b/setup.py
@@ -16,11 +16,11 @@ script_dirname = os.path.join(os.path.dirname(__file__))
 __VERSION__ = None
 # get __VERSION__ variable from file
 version_file = os.path.join(script_dirname, 'version.py')
-exec(open(version_file).read())
+exec(open(version_file).read().decode("utf-8"))
 
 
 def read(readme):
-    return open(os.path.join(script_dirname, readme)).read()
+    return open(os.path.join(script_dirname, readme)).read().decode("utf-8")
 
 setup(
     name='urlextract',


### PR DESCRIPTION
Running pip install urlextract where LANG is not UTF-8 (e.g. my continuous deployment container) fails without this patch. This is because setup.py runs open('version.py').read(), which in turn opens the file in text mode. On Python 3, this uses the ASCII codec, but version.py contains UTF-8 characters.

This patch forcibly parses 'version.py' as UTF-8 regardless of the user's codec.