### PR TITLE
Pytest: use integrated pytest doctest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,4 @@ install:
 - pip install -e .
 # commands to run tests
 script:
-- python3 -m doctest urlextract.py
-- pytest
+- pytest --doctest-modules --ignore setup.py


### PR DESCRIPTION
There is no need for extra doctest testing section. Pytest can do docstrings.