### PR TITLE
Allow setting of a base dir for url cache

### DIFF
--- a/urlextract.py
+++ b/urlextract.py
@@ -71,7 +71,7 @@ class URLExtract:
         ("`", "`"),
     }
 
-    def __init__(self, cache_dir=os.path.dirname(__file__)):
+    def __init__(self, cache_dir=None):
         """
         Initialize function for URLExtract class.
         Tries to get cached .tlds, if cached file does not exist it will try
@@ -81,6 +81,11 @@ class URLExtract:
         :raises: CacheFileError when cached file is not readable for user
         """
         self._logger = logging.getLogger(__name__)
+
+        # default to the current directory for cache
+        if cache_dir is None:
+            cache_dir = os.path.dirname(__file__)
+
         # get directory for cached file
         dir_path = cache_dir
         if not os.access(dir_path, os.W_OK):

--- a/urlextract.py
+++ b/urlextract.py
@@ -71,17 +71,18 @@ class URLExtract:
         ("`", "`"),
     }
 
-    def __init__(self):
+    def __init__(self, cache_dir=os.path.dirname(__file__)):
         """
         Initialize function for URLExtract class.
         Tries to get cached .tlds, if cached file does not exist it will try
         to download new list from IANNA and save it to users home directory.
 
+        :param str cache_dir: base path for tld cache, defaults to os.path.dirname(__file__)
         :raises: CacheFileError when cached file is not readable for user
         """
         self._logger = logging.getLogger(__name__)
         # get directory for cached file
-        dir_path = os.path.dirname(__file__)
+        dir_path = cache_dir
         if not os.access(dir_path, os.W_OK):
             # get path to home dir
             dir_path = os.path.expanduser('~')


### PR DESCRIPTION
I'm using this library in an application deployed on AWS Elastic Beanstalk. In it's environment, `os.path.dirname(__file__)` would resolve to an unwriteable directory. I've added the _optional_ `cache_dir` parameter to the constructor, defaulting to the value it was previously, to allow code to explicitly set a base cache directory.