### PR TITLE
Allow to use localhost as tld.

### DIFF
--- a/tests/unit/test_find_urls.py
+++ b/tests/unit/test_find_urls.py
@@ -49,6 +49,8 @@ import pytest
     ("http://0.0.0.0/a.io",
      ['http://0.0.0.0/a.io']),
 
+    ("Local development url http://localhost:8000/",
+        ['http://localhost:8000/']),
 ])
 def test_find_urls(urlextract, text, expected):
     """

--- a/urlextract/urlextract_core.py
+++ b/urlextract/urlextract_core.py
@@ -118,6 +118,7 @@ class URLExtract(CacheFile):
 
         tlds = sorted(self._load_cached_tlds(), key=len, reverse=True)
         tlds += self._ipv4_tld
+        tlds.append('localhost')
         re_escaped = [re.escape(str(tld)) for tld in tlds]
         self._tlds_re = re.compile('|'.join(re_escaped))
 
@@ -528,6 +529,10 @@ class URLExtract(CacheFile):
                 return False
 
         host_parts = host.split('.')
+
+        if host_parts == ['localhost']:
+            return True
+
         if len(host_parts) <= 1:
             return False
 


### PR DESCRIPTION
I found that `found_urls` did not work when the top-level domain was `localhost`.

I added a test, and tried to fix it.