### PR TITLE
Indices of found URLs

### DIFF
--- a/tests/unit/test_find_urls.py
+++ b/tests/unit/test_find_urls.py
@@ -79,3 +79,19 @@ def test_find_urls_unique(urlextract, text, expected):
     :param list(str) expected: list of URLs that has to be found in text
     """
     assert urlextract.find_urls(text, only_unique=True) == expected
+
+
+@pytest.mark.parametrize("text, expected", [
+    ("Let's have URL http://janlipovsky.cz and a second URL https://example.com/@eon01/asdsd-dummy it's over.",
+     [('http://janlipovsky.cz', (15, 36)),
+      ('https://example.com/@eon01/asdsd-dummy', (54, 92))]),
+])
+def test_find_urls_with_indices(urlextract, text, expected):
+    """
+    Testing find_urls returning only unique URLs
+
+    :param fixture urlextract: fixture holding URLExtract object
+    :param str text: text in which we should find links
+    :param list(str) expected: list of URLs that has to be found in text
+    """
+    assert urlextract.find_urls(text, get_indices=True) == expected

--- a/urlextract/urlextract_core.py
+++ b/urlextract/urlextract_core.py
@@ -703,9 +703,8 @@ class URLExtract(CacheFile):
         :param bool check_dns: filter results to valid domains
         :param bool get_indices: whether to return beginning and
             ending indices as (<url>, (idx_begin, idx_end))
-        :yields: URL found in text or empty string if no found
-        :rtype: - str if not get_indices
-                - Tuple[str, Tuple[int, int]] if get_indices
+        :yields: URL or URL with indices found in text or empty string if nothing was found
+        :rtype: str|tuple(str, tuple(int, int))
         """
         tld_pos = 0
         matched_tlds = self._tlds_re.findall(text)


### PR DESCRIPTION
Added a new attribute when searching for URLs to return the URLs as well as beginning and ending indices: solve #71.

```python
extractor = URLExtract()
example_text = "Text with URLs. Let's have URL janlipovsky.cz as an example."

for url in extractor.gen_urls(example_text, get_indices=True):
    print(url) # prints: ('janlipovsky.cz', (31, 45))
```

By default, `get_indices=False` for code compatibility.