### PR TITLE
Add a list of URLs allowed to extract

### DIFF
--- a/docs/urlextract_cmd.rst
+++ b/docs/urlextract_cmd.rst
@@ -17,7 +17,7 @@ optional arguments:
   -c, --check-dns       print out only URLs for existing domain names
   -i <ignore_file>, --ignore-file <ignore_file>
                         input text file with URLs to exclude from extraction
-  -hl <host_limit_file>, --host-limit-file <host_limit_file>
+  -p <permit_file>, --permit-file <permit_file>
                         input text file with URLs that can be processed
   -l LIMIT, --limit LIMIT
                         Maximum count of URLs that can be processed. Set 0 to

--- a/docs/urlextract_cmd.rst
+++ b/docs/urlextract_cmd.rst
@@ -3,7 +3,7 @@ urlextract - command line
 
 urlextract - command line program that will print all URLs to stdout
 
-Usage: ``$ urlextract [-h] [-v] [-u] [-dl] [-c] [-i <ignore_file>] [-hl <host_limit_file>] [-l LIMIT] [<input_file>]``
+Usage: ``$ urlextract [-h] [-v] [-u] [-dl] [-c] [-i <ignore_file>] [-p <permit_file>] [-l LIMIT] [<input_file>]``
 
 positional arguments:
   <input_file>          input text file with URLs to extract

--- a/docs/urlextract_cmd.rst
+++ b/docs/urlextract_cmd.rst
@@ -3,7 +3,7 @@ urlextract - command line
 
 urlextract - command line program that will print all URLs to stdout
 
-Usage: ``$ urlextract [-h] [-v] [-u] [-dl] [-c] [-i <ignore_file>] [-l LIMIT] [<input_file>]``
+Usage: ``$ urlextract [-h] [-v] [-u] [-dl] [-c] [-i <ignore_file>] [-hl <host_limit_file>] [-l LIMIT] [<input_file>]``
 
 positional arguments:
   <input_file>          input text file with URLs to extract
@@ -17,6 +17,8 @@ optional arguments:
   -c, --check-dns       print out only URLs for existing domain names
   -i <ignore_file>, --ignore-file <ignore_file>
                         input text file with URLs to exclude from extraction
+  -hl <host_limit_file>, --host-limit-file <host_limit_file>
+                        input text file with URLs that can be processed
   -l LIMIT, --limit LIMIT
                         Maximum count of URLs that can be processed. Set 0 to
                         disable the limit. Default: 10000

--- a/tests/unit/test_host_limit_list.py
+++ b/tests/unit/test_host_limit_list.py
@@ -19,8 +19,10 @@ import pytest
         ("one-another-url.com", []),
         ("http://example.com", ["http://example.com"]),
         ("http://example.com:1234", ["http://example.com:1234"]),
-        ("http://example.com:1234 http://example.com admin@example.com", 
-                    ["http://example.com:1234", "http://example.com", "admin@example.com"]),
+        (
+            "http://example.com:1234 http://example.com admin@example.com example123.com",
+            ["http://example.com:1234", "http://example.com"],
+        ),
         ("admin@example.com", []),
         ("ftp://admin:pass@example.com", ["ftp://admin:pass@example.com"]),
         (
@@ -41,6 +43,7 @@ def test_host_limit_list(urlextract, text, expected):
     """
     urlextract.host_limit_list = {"example.com", "another-url.com"}
     assert expected == urlextract.find_urls(text)
+
 
 @pytest.mark.parametrize(
     "text, expected",
@@ -73,6 +76,7 @@ def test_host_limit_list_with_ignore(urlextract, text, expected):
     urlextract.ignore_list = {"another-url.com"}
     assert expected == urlextract.find_urls(text)
 
+
 @pytest.mark.parametrize(
     "text, expected",
     [
@@ -104,10 +108,14 @@ def test_host_limit_list_with_emails(urlextract, text, expected):
     urlextract.host_limit_list = {"example.com", "another-url.com"}
     assert expected == urlextract.find_urls(text)
 
+
 @pytest.mark.parametrize(
     "text, expected",
     [
-        ("Local development url http://localhost:8000/ and www.example.com", ["http://localhost:8000/"]),
+        (
+            "Local development url http://localhost:8000/ and www.example.com",
+            ["http://localhost:8000/"],
+        ),
         ("Some text with  localhost in it", []),
     ],
 )
@@ -121,6 +129,7 @@ def test_host_limit_localhost_enabled(urlextract, text, expected):
     """
     urlextract.host_limit_list = {"localhost"}
     assert expected == urlextract.find_urls(text)
+
 
 @pytest.mark.parametrize(
     "text, expected",
@@ -140,4 +149,3 @@ def test_host_limit_localhost_disabled(urlextract, text, expected):
     urlextract.extract_localhost = False
     urlextract.host_limit_list = {"localhost"}
     assert expected == urlextract.find_urls(text)
-

--- a/tests/unit/test_host_limit_list.py
+++ b/tests/unit/test_host_limit_list.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+This file contains pytests for find_urls() method of URLExtract with
+list of URLs that can be processed
+
+.. Licence MIT
+.. codeauthor:: khoben <extless@gmail.com>
+"""
+import pytest
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("example.com", ["example.com"]),
+        ("ample.com", []),
+        ("another-url.com", ["another-url.com"]),
+        ("one-another-url.com", []),
+        ("http://example.com", ["http://example.com"]),
+        ("http://example.com:1234", ["http://example.com:1234"]),
+        ("admin@example.com", []),
+        ("ftp://admin:pass@example.com", ["ftp://admin:pass@example.com"]),
+        (
+            "http://subdom.example.com:1234/path/file.html?query=something#hashtag",
+            [],
+        ),
+        ("www.example.com", []),
+        ("example.net", []),
+    ],
+)
+def test_host_limit_list(urlextract, text, expected):
+    """
+    Testing find_urls with list of URLs that can be processed
+
+    :param fixture urlextract: fixture holding URLExtract object
+    :param str text: text in which we should find links
+    :param list(str) expected: list of URLs that has to be found in text
+    """
+    urlextract.host_limit_list = {"example.com", "another-url.com"}
+    assert expected == urlextract.find_urls(text)
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("example.com", ["example.com"]),
+        ("ample.com", []),
+        ("another-url.com", []),
+        ("one-another-url.com", []),
+        ("http://example.com", ["http://example.com"]),
+        ("http://example.com:1234", ["http://example.com:1234"]),
+        ("admin@example.com", []),
+        ("ftp://admin:pass@example.com", ["ftp://admin:pass@example.com"]),
+        (
+            "http://subdom.example.com:1234/path/file.html?query=something#hashtag",
+            [],
+        ),
+        ("www.example.com", []),
+        ("example.net", []),
+    ],
+)
+def test_host_limit_list_with_ignore(urlextract, text, expected):
+    """
+    Testing find_urls with list of URLs list that can be processed and URLs ignore list
+
+    :param fixture urlextract: fixture holding URLExtract object
+    :param str text: text in which we should find links
+    :param list(str) expected: list of URLs that has to be found in text
+    """
+    urlextract.host_limit_list = {"example.com", "another-url.com"}
+    urlextract.ignore_list = {"another-url.com"}
+    assert expected == urlextract.find_urls(text)
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("example.com", ["example.com"]),
+        ("ample.com", []),
+        ("another-url.com", ["another-url.com"]),
+        ("one-another-url.com", []),
+        ("http://example.com", ["http://example.com"]),
+        ("http://example.com:1234", ["http://example.com:1234"]),
+        ("admin@example.com", ["admin@example.com"]),
+        ("ftp://admin:pass@example.com", ["ftp://admin:pass@example.com"]),
+        (
+            "http://subdom.example.com:1234/path/file.html?query=something#hashtag",
+            [],
+        ),
+        ("www.example.com", []),
+        ("example.net", []),
+    ],
+)
+def test_host_limit_list_with_emails(urlextract, text, expected):
+    """
+    Testing find_urls with list of URLs that can be processed with email addresses
+
+    :param fixture urlextract: fixture holding URLExtract object
+    :param str text: text in which we should find links
+    :param list(str) expected: list of URLs that has to be found in text
+    """
+    urlextract.extract_email = True
+    urlextract.host_limit_list = {"example.com", "another-url.com"}
+    assert expected == urlextract.find_urls(text)
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("Local development url http://localhost:8000/ and www.example.com", ["http://localhost:8000/"]),
+        ("Some text with  localhost in it", []),
+    ],
+)
+def test_host_limit_localhost_enabled(urlextract, text, expected):
+    """
+    Testing find_urls with list of URLs that can be processed with localhost
+
+    :param fixture urlextract: fixture holding URLExtract object
+    :param str text: text in which we should find links
+    :param list(str) expected: list of URLs that has to be found in text
+    """
+    urlextract.host_limit_list = {"localhost"}
+    assert expected == urlextract.find_urls(text)
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("Local development url http://localhost:8000/", []),
+        ("Some text with  localhost in it", []),
+    ],
+)
+def test_host_limit_localhost_disabled(urlextract, text, expected):
+    """
+    Testing find_urls with list of URLs that can be processed without localhost
+
+    :param fixture urlextract: fixture holding URLExtract object
+    :param str text: text in which we should find links
+    :param list(str) expected: list of URLs that has to be found in text
+    """
+    urlextract.extract_localhost = False
+    urlextract.host_limit_list = {"localhost"}
+    assert expected == urlextract.find_urls(text)
+

--- a/tests/unit/test_host_limit_list.py
+++ b/tests/unit/test_host_limit_list.py
@@ -19,6 +19,8 @@ import pytest
         ("one-another-url.com", []),
         ("http://example.com", ["http://example.com"]),
         ("http://example.com:1234", ["http://example.com:1234"]),
+        ("http://example.com:1234 http://example.com admin@example.com", 
+                    ["http://example.com:1234", "http://example.com", "admin@example.com"]),
         ("admin@example.com", []),
         ("ftp://admin:pass@example.com", ["ftp://admin:pass@example.com"]),
         (

--- a/tests/unit/test_permit_list.py
+++ b/tests/unit/test_permit_list.py
@@ -33,7 +33,7 @@ import pytest
         ("example.net", []),
     ],
 )
-def test_host_limit_list(urlextract, text, expected):
+def test_permit_list(urlextract, text, expected):
     """
     Testing find_urls with list of URLs that can be processed
 
@@ -41,7 +41,7 @@ def test_host_limit_list(urlextract, text, expected):
     :param str text: text in which we should find links
     :param list(str) expected: list of URLs that has to be found in text
     """
-    urlextract.host_limit_list = {"example.com", "another-url.com"}
+    urlextract.permit_list = {"example.com", "another-url.com"}
     assert expected == urlextract.find_urls(text)
 
 
@@ -64,7 +64,7 @@ def test_host_limit_list(urlextract, text, expected):
         ("example.net", []),
     ],
 )
-def test_host_limit_list_with_ignore(urlextract, text, expected):
+def test_permit_list_with_ignore(urlextract, text, expected):
     """
     Testing find_urls with list of URLs list that can be processed and URLs ignore list
 
@@ -72,7 +72,7 @@ def test_host_limit_list_with_ignore(urlextract, text, expected):
     :param str text: text in which we should find links
     :param list(str) expected: list of URLs that has to be found in text
     """
-    urlextract.host_limit_list = {"example.com", "another-url.com"}
+    urlextract.permit_list = {"example.com", "another-url.com"}
     urlextract.ignore_list = {"another-url.com"}
     assert expected == urlextract.find_urls(text)
 
@@ -96,7 +96,7 @@ def test_host_limit_list_with_ignore(urlextract, text, expected):
         ("example.net", []),
     ],
 )
-def test_host_limit_list_with_emails(urlextract, text, expected):
+def test_permit_list_with_emails(urlextract, text, expected):
     """
     Testing find_urls with list of URLs that can be processed with email addresses
 
@@ -105,7 +105,7 @@ def test_host_limit_list_with_emails(urlextract, text, expected):
     :param list(str) expected: list of URLs that has to be found in text
     """
     urlextract.extract_email = True
-    urlextract.host_limit_list = {"example.com", "another-url.com"}
+    urlextract.permit_list = {"example.com", "another-url.com"}
     assert expected == urlextract.find_urls(text)
 
 
@@ -127,7 +127,7 @@ def test_host_limit_localhost_enabled(urlextract, text, expected):
     :param str text: text in which we should find links
     :param list(str) expected: list of URLs that has to be found in text
     """
-    urlextract.host_limit_list = {"localhost"}
+    urlextract.permit_list = {"localhost"}
     assert expected == urlextract.find_urls(text)
 
 
@@ -147,5 +147,5 @@ def test_host_limit_localhost_disabled(urlextract, text, expected):
     :param list(str) expected: list of URLs that has to be found in text
     """
     urlextract.extract_localhost = False
-    urlextract.host_limit_list = {"localhost"}
+    urlextract.permit_list = {"localhost"}
     assert expected == urlextract.find_urls(text)

--- a/urlextract/urlextract_core.py
+++ b/urlextract/urlextract_core.py
@@ -68,7 +68,7 @@ class URLExtract(CacheFile):
 
     _ipv4_tld = [".{}".format(ip) for ip in reversed(range(256))]
     _ignore_list = set()
-    _host_limit_list = set()
+    _permit_list = set()
 
     _limit = DEFAULT_LIMIT
 
@@ -211,27 +211,27 @@ class URLExtract(CacheFile):
                 self._ignore_list.add(url)
 
     @property
-    def host_limit_list(self):
+    def permit_list(self):
         """
         Returns set of URLs that can be processed
 
         :return: Returns set of URLs that can be processed
         :rtype: set(str)
         """
-        return self._host_limit_list
+        return self._permit_list
 
-    @host_limit_list.setter
-    def host_limit_list(self, host_limit_list):
+    @permit_list.setter
+    def permit_list(self, permit_list):
         """
         Set of URLs that can be processed
 
-        :param set(str) host_limit_list: set of URLs
+        :param set(str) permit_list: set of URLs
         """
-        self._host_limit_list = host_limit_list
+        self._permit_list = permit_list
 
-    def load_host_limit_list(self, file_name):
+    def load_permit_list(self, file_name):
         """
-        Load URLs from file into host limit list
+        Load URLs from file into permit list
 
         :param str file_name: path to file containing URLs
         """
@@ -240,7 +240,7 @@ class URLExtract(CacheFile):
                 url = line.strip()
                 if not url:
                     continue
-                self._host_limit_list.add(url)
+                self._permit_list.add(url)
 
     def update(self):
         """
@@ -598,7 +598,7 @@ class URLExtract(CacheFile):
         if not host:
             return False
 
-        if self._host_limit_list and host not in self._host_limit_list:
+        if self._permit_list and host not in self._permit_list:
             return False
 
         if host in self._ignore_list:
@@ -978,9 +978,9 @@ def _urlextract_cli():
         )
 
         parser.add_argument(
-            "-hl",
-            "--host-limit-file",
-            metavar="<host_limit_file>",
+            "-p",
+            "--permit-file",
+            metavar="<permit_file>",
             type=str,
             default=None,
             help="input text file with URLs that can be processed",
@@ -1024,8 +1024,8 @@ def _urlextract_cli():
             urlextract.extract_localhost = False
         if args.ignore_file:
             urlextract.load_ignore_list(args.ignore_file)
-        if args.host_limit_file:
-            urlextract.load_host_limit_list(args.host_limit_file)
+        if args.permit_file:
+            urlextract.load_permit_list(args.permit_file)
         urlextract.update_when_older(30)
         content = args.input_file.read()
         try:


### PR DESCRIPTION
```python
text = "google.com twitter.com example.com example.com/test.html"
urlextract.permit_list = {"example.com"}
print(urlextract.find_urls(text)) # => ["example.com", "example.com/test.html"]
```